### PR TITLE
Added babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "request": "^2.75.0"
   },
   "devDependencies": {
+    "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",


### PR DESCRIPTION
gulp dev fails due to babel-core missing. I added it.
